### PR TITLE
Fix: CMSIS-DAP multi-TAP target selection

### DIFF
--- a/orbtrace/debug/cmsis_dap.py
+++ b/orbtrace/debug/cmsis_dap.py
@@ -553,7 +553,7 @@ class CMSIS_DAP(Elaboratable):
         # We have the command, index and transfer count, need to set up to get the transfers
 
         m.d.sync += [
-            self.dbgif.dev.eq(self.rxBlock.bit_select(13,3)),
+            self.dbgif.dev.eq(self.rxBlock.bit_select(8,3)),
             self.transferTCount.eq(self.rxBlock.bit_select(16,8)),
             self.tfrram.adr.eq(0),
             self.tfr_txb.eq(0),


### PR DESCRIPTION
While debugging CMSIS-DAP issues in BMDA, we found that ORBTrace was seemingly ignoring the DAP Index byte in DAP_TRANSFER packets, and always using the 1st (0th by index) TAP even in a multi-TAP system. This PR addresses this by selecting the correct bits from the packet.