### PR TITLE
bugfix/python_path: fix for PYTHONPATH

### DIFF
--- a/deps/__init__.py
+++ b/deps/__init__.py
@@ -6,7 +6,7 @@ ignore = [
 	'__pycache__',
 ]
 
-paths = [str(p) for p in pathlib.Path(__file__).parent.iterdir() if p.is_dir() and p not in ignore]
+paths = [str(p) for p in pathlib.Path(__file__).parent.iterdir() if p.is_dir() and p.name not in ignore]
 
 for p in paths:
 	sys.path.insert(1, p)


### PR DESCRIPTION
This commit fixes deps/__init__.py to correctly ignore the directory names listed in the ignore[] list.  Either check the full path or just path.name.