### PR TITLE
Fix: SWD no-response data phase handling

### DIFF
--- a/verilog/swdIF.v
+++ b/verilog/swdIF.v
@@ -156,7 +156,8 @@ module swdIF (
                     if (bitcount==PROT_ACK_END)                                            // Have now done
                       begin
                          ack <= {swdi,rd[31:30]};                                          // Store the ACK
-			 if ({swdi,rd[31:30]}==3'b001)                                    // Its a good one
+			 if (({swdi,rd[31:30]}==3'b001) ||                             // Its a good one or
+			   ({swdi,rd[31:30]}==3'b111))                                // we got no-response
                            begin
                               if (rnw)                                               // ..and we're reading
 				begin

--- a/verilog/swdIF.v
+++ b/verilog/swdIF.v
@@ -107,7 +107,7 @@ module swdIF (
 			   (((bitcount==PROT_PAR) && rising) || (bitcount>PROT_PAR))
 			   );
 	  end
-	
+
         if (rising)
           begin
              bitcount <= bitcount+1;                                                            // Next bit
@@ -118,7 +118,7 @@ module swdIF (
                ST_IDLE: // Idle waiting for something to happen ===========================================
                  begin
                     bitcount  <= 0;
-		    
+
                     if (go)                                                  // Request to start a transfer
                       begin
 			 swd_state <= ST_HDR_TX;
@@ -142,7 +142,7 @@ module swdIF (
                  begin
                     spincount<=spincount-1;                                             // Turn in progress
 		    bitcount <= PROT_TRN1;
-		    
+
                     if (spincount==0)
 		      begin
 			 bitcount  <= PROT_ACK;                              // ... and leave the TRN state
@@ -218,7 +218,7 @@ module swdIF (
 	       // =========================================================================================
 	       default: // Anything else ==================================================================
 		 swd_state <= ST_IDLE;
-	       
+
              endcase // case (swd_state) ==================================================================
           end // if (rising)
      end // always @ (posedge clk)


### PR DESCRIPTION
In this PR, following discussion on the BMD channel on 1b² Discord, we address ORBTrace's handling of the SWD no-response data phase which was previously not being generated.

This phase must be generated per ADIv5.2 §B4.2.5 (Protocol error response) subsection "Host response to protocol errors", first paragraph - "If the host does not receive an expected response from the target, it must not drive the line for at least the length of any potential data phase and then attempt a line reset". Otherwise targets get deeply unhappy and become unrecoverable by protocol recovery.